### PR TITLE
Potential fix for code scanning alert no. 13: Server-side request forgery

### DIFF
--- a/pages/api/trends/audio.ts
+++ b/pages/api/trends/audio.ts
@@ -3,6 +3,13 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 
 import { ITrends } from '../../../interfaces/trends'
 
+
+// Whitelist of supported country codes (could be expanded as needed)
+const ALLOWED_COUNTRY_CODES = [
+  "us", "gb", "fr", "de", "jp", "ca", "au", "it", "es", "nl", "se", "ch", "no", "dk", "fi", "be", "nz", "br", "tr", "mx", "ru", "pl", "cn", "kr", "hk", "sg", "ie", "pt", "cz", "at", "gr", "hu", "il", "za", "ae", "sa", "ar", "cl", "co", "ec", "fi", "in", "my", "th", "vn"
+  // ... add other supported codes as needed
+];
+
 export default async function endpoint(
   req: NextApiRequest,
   res: NextApiResponse
@@ -15,7 +22,13 @@ export default async function endpoint(
     return res.status(400).json({ message: 'Missing parameter COUNTRY_CODE' })
   }
 
-  const url = `https://rss.applemarketingtools.com/api/v2/${country}/music/most-played/28/albums.json`
+  // Defensive normalization and validation
+  const normCountry = (typeof country === 'string') ? country.toLowerCase() : '';
+  if (!ALLOWED_COUNTRY_CODES.includes(normCountry)) {
+    return res.status(400).json({ message: 'Invalid COUNTRY_CODE' });
+  }
+
+  const url = `https://rss.applemarketingtools.com/api/v2/${normCountry}/music/most-played/28/albums.json`
 
   try {
     const { data } = await axios.get(url)


### PR DESCRIPTION
Potential fix for [https://github.com/lucasm/findto/security/code-scanning/13](https://github.com/lucasm/findto/security/code-scanning/13)

The best way to address this SSRF risk is to validate the `country` parameter against a whitelist of known, permitted country codes (e.g., a hardcoded list of ISO 3166-1 alpha-2 codes supported by the Apple API). Only values present in the whitelist should be accepted; others should result in a 400 Bad Request response. This restriction prevents arbitrary user input from being included in the request path and eliminates the possibility of path traversal or other manipulations via crafted input. To implement this, introduce a set of allowed country codes, perform a strict check on `country`, and return an error if validation fails. The changes are entirely within pages/api/trends/audio.ts, requiring code edits to add the whitelist and validation logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
